### PR TITLE
feat: implement workflow executors

### DIFF
--- a/.github/workflows/report-to-notion.yml
+++ b/.github/workflows/report-to-notion.yml
@@ -1,0 +1,63 @@
+name: Report merged PR to Notion
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  report-to-notion:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send merged PR summary to Notion
+        env:
+          NOTION_API_TOKEN: ${{ secrets.NOTION_API_TOKEN }}
+          NOTION_PARENT_PAGE_ID: ${{ secrets.NOTION_PARENT_PAGE_ID }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import requests
+
+          token = os.environ.get('NOTION_API_TOKEN')
+          parent_id = os.environ.get('NOTION_PARENT_PAGE_ID')
+
+          if not token or not parent_id:
+              raise SystemExit('NOTION_API_TOKEN and NOTION_PARENT_PAGE_ID are required repository secrets.')
+
+          title = os.environ.get('PR_TITLE', 'Merged PR')
+          pr_url = os.environ.get('PR_URL', '')
+          pr_number = os.environ.get('PR_NUMBER', '')
+          pr_body = os.environ.get('PR_BODY', '')[:1500]
+
+          content = f"PR #{pr_number}: {title}\n{pr_url}\n\n{pr_body}"
+
+          headers = {
+              'Authorization': f'Bearer {token}',
+              'Content-Type': 'application/json',
+              'Notion-Version': '2022-06-28',
+          }
+          payload = {
+              'parent': {'page_id': parent_id},
+              'properties': {
+                  'title': {
+                      'title': [{'text': {'content': f"Merged PR #{pr_number}: {title}"}}]
+                  }
+              },
+              'children': [
+                  {
+                      'object': 'block',
+                      'type': 'paragraph',
+                      'paragraph': {
+                          'rich_text': [{'type': 'text', 'text': {'content': content}}]
+                      }
+                  }
+              ]
+          }
+          response = requests.post('https://api.notion.com/v1/pages', headers=headers, json=payload, timeout=30)
+          response.raise_for_status()
+          print('Notion page created for merged PR report.')
+          PY

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,31 @@
+name: Validate Pull Request
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required PR sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredHeaders = [
+              '## Origem',
+              '## Objetivo',
+              '## Escopo',
+              '## Validação',
+              '## Evidências',
+              '## Riscos'
+            ];
+
+            const body = context.payload.pull_request.body || '';
+            const missing = requiredHeaders.filter((header) => !body.includes(header));
+
+            if (missing.length > 0) {
+              core.setFailed(`PR incompleto. Seções ausentes: ${missing.join(', ')}`);
+            } else {
+              core.info('PR contém todas as seções obrigatórias.');
+            }

--- a/docs/governance/branch-naming.md
+++ b/docs/governance/branch-naming.md
@@ -1,0 +1,38 @@
+# Branch Naming Policy
+
+Esta política define nomes de branch para humanos e agentes. O objetivo é manter rastreabilidade entre captura, issue, execução, PR e relatório.
+
+## Formato
+
+```text
+<tipo>/<issue>-<descricao-curta>
+```
+
+## Tipos permitidos
+
+- `feat`: nova funcionalidade ou novo executor.
+- `fix`: correção de comportamento.
+- `docs`: documentação, ADR, política ou relatório.
+- `chore`: manutenção operacional.
+- `refactor`: reorganização sem mudança de comportamento.
+- `test`: teste, avaliação ou validação automatizada.
+- `research`: experimento, hipótese ou protótipo científico.
+
+## Exemplos
+
+```text
+feat/11-workflow-executors
+docs/11-update-tool-roles
+research/12-quotes-eval
+```
+
+## Regras
+
+1. Toda branch deve apontar para uma issue quando houver trabalho rastreável.
+2. Agentes não trabalham diretamente em `main` nem em branches canônicas.
+3. Branches devem ser curtas, sem acentos e em kebab-case.
+4. O PR deve referenciar a issue de origem e o relatório de execução quando aplicável.
+
+## Integrações
+
+Linear, ClickUp e Slack podem referenciar a mesma issue GitHub, mas não substituem a branch nem o PR. Eles existem como camadas de coordenação, operação e comunicação.

--- a/docs/governance/integration-routing.md
+++ b/docs/governance/integration-routing.md
@@ -1,0 +1,42 @@
+# Integration Routing Policy
+
+Esta política define quando usar Notion, GitHub, Linear, ClickUp e Slack no fluxo do Ora Brasiliae OS.
+
+## Regra central
+
+GitHub continua sendo o ledger canônico. As demais ferramentas são nós auxiliares do fluxo. Elas podem capturar, coordenar, comunicar ou espelhar estado, mas não substituem issue, PR, commit, ADR ou relatório versionado.
+
+## Roteamento por ferramenta
+
+### Notion
+
+Use para captura bruta, rascunhos, ideação e visibilidade gerencial. Conteúdo do Notion só entra no GitHub quando estiver aprovado e for promovido por issue ou PR.
+
+### GitHub
+
+Use para código, documentação versionada, governança, issues, branches, pull requests, ADRs e reports. Quando houver conflito entre ferramentas, o GitHub prevalece.
+
+### Linear
+
+Use quando a tarefa precisar de backlog estruturado, ciclo, milestone, projeto de produto ou delegação para time de engenharia. A issue do Linear deve apontar para a issue ou PR correspondente no GitHub quando o trabalho alterar o repositório.
+
+### ClickUp
+
+Use para tarefas operacionais, rotina pessoal, calendário, execução recorrente ou acompanhamento administrativo. O ClickUp pode espelhar uma tarefa GitHub, mas não decide arquitetura nem estado canônico.
+
+### Slack
+
+Use para alinhamento rápido, pedidos de revisão e status compartilhável. Decisões relevantes tomadas no Slack devem ser promovidas de volta ao GitHub como comentário, issue, ADR ou relatório.
+
+## Matriz de decisão
+
+- Ideia solta: Notion.
+- Trabalho versionável: GitHub Issue.
+- Planejamento de produto: Linear.
+- Execução operacional: ClickUp.
+- Comunicação rápida: Slack.
+- Decisão durável: GitHub ADR ou report.
+
+## Anti-padrão evitado
+
+Não transportar conversas inteiras entre ferramentas. O fluxo deve transportar estado mínimo: objetivo, contexto, decisão, evidência, risco e próximo passo.

--- a/reports/executions/2026-04-25-workflow-executors.md
+++ b/reports/executions/2026-04-25-workflow-executors.md
@@ -1,0 +1,41 @@
+# Execution Report: Workflow Executors
+
+## Origem
+GitHub Issue #11: Implementar executores mínimos do workflow OS.
+
+## Status
+REVIEW
+
+## Objetivo
+Implementar executores mínimos para reduzir o transporte manual de contexto entre IAs e ferramentas, preservando GitHub como ledger canônico e Notion como captura bruta.
+
+## Escopo executado
+
+- Criada branch `feat/11-workflow-executors`.
+- Criado script `scripts/notion_to_issue.py` para promover páginas aprovadas do Notion em issues GitHub.
+- Criado script `scripts/generate_context_package.py` para gerar pacote mínimo de contexto a partir de issue GitHub.
+- Criada política `docs/governance/branch-naming.md` para padronização de branches.
+- Criado workflow `.github/workflows/validate-pr.yml` para validar se PRs têm seções obrigatórias.
+- Criado workflow `.github/workflows/report-to-notion.yml` para reportar PRs mergeados ao Notion.
+- Criada política `docs/governance/integration-routing.md` incorporando Notion, GitHub, Linear, ClickUp e Slack ao fluxo.
+
+## Validação
+
+Validação estrutural por inspeção dos arquivos criados e alinhamento com a regra central do repositório: GitHub como ledger canônico, Notion como captura bruta e PR obrigatório.
+
+## Evidências
+
+- Branch: `feat/11-workflow-executors`.
+- Issue: #11.
+- PR esperado: abrir contra `governance/bootstrap`.
+
+## Riscos
+
+- Os workflows dependem de secrets do repositório: `NOTION_API_TOKEN` e `NOTION_PARENT_PAGE_ID`.
+- O script `notion_to_issue.py` depende de schema mínimo no Notion: propriedades `Status`, opcionalmente `Description` e `Type`.
+- A sincronização automática pode duplicar issues se não houver campo externo de controle de páginas já promovidas.
+- Linear, ClickUp e Slack foram documentados como nós auxiliares, mas integrações automáticas completas ainda precisam de rotas específicas por caso de uso.
+
+## Próximo passo recomendado
+
+Revisar o PR, configurar secrets no GitHub e definir se haverá campo no Notion para registrar `GitHub Issue URL` após promoção.

--- a/scripts/generate_context_package.py
+++ b/scripts/generate_context_package.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+generate_context_package.py
+---------------------------
+
+Gera um pacote de contexto mínimo a partir de uma issue do GitHub.
+
+Objetivo:
+- Evitar transportar conversas inteiras entre IAs.
+- Transformar a issue canônica em um resumo curto e reutilizável.
+- Alimentar agentes, Slack, Linear ou ClickUp com estado, não ruído.
+
+Uso com GitHub CLI:
+    gh issue view 11 --json number,title,body,url,labels,state \
+      | python3 scripts/generate_context_package.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any, Dict, Iterable, List
+
+
+MAX_BODY_LINES = 12
+MAX_CHARS = 1800
+
+
+def clean_lines(text: str) -> List[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def extract_checklist(lines: Iterable[str]) -> List[str]:
+    checklist = []
+    for line in lines:
+        if re.match(r"^- \[[ xX]\] ", line):
+            checklist.append(line)
+    return checklist
+
+
+def label_names(issue: Dict[str, Any]) -> List[str]:
+    labels = issue.get("labels", []) or []
+    names = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and label.get("name"):
+            names.append(label["name"])
+    return names
+
+
+def generate_summary(issue: Dict[str, Any]) -> str:
+    number = issue.get("number") or issue.get("issue_number") or "?"
+    title = issue.get("title", "Untitled")
+    state = issue.get("state", "unknown")
+    url = issue.get("url") or issue.get("html_url") or ""
+    body = issue.get("body", "") or ""
+    lines = clean_lines(body)
+    excerpt = "\n".join(lines[:MAX_BODY_LINES])
+    checklist = extract_checklist(lines)
+    labels = ", ".join(label_names(issue)) or "none"
+
+    parts = [
+        f"Issue: #{number} - {title}",
+        f"Estado: {state}",
+        f"Labels: {labels}",
+    ]
+    if url:
+        parts.append(f"URL: {url}")
+    if excerpt:
+        parts.append("\nContexto essencial:\n" + excerpt)
+    if checklist:
+        parts.append("\nChecklist detectado:\n" + "\n".join(checklist[:8]))
+
+    summary = "\n".join(parts)
+    if len(summary) > MAX_CHARS:
+        summary = summary[: MAX_CHARS - 20].rstrip() + "\n...[truncated]"
+    return summary
+
+
+def main() -> None:
+    issue_json = json.load(sys.stdin)
+    print(generate_summary(issue_json))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notion_to_issue.py
+++ b/scripts/notion_to_issue.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+notion_to_issue.py
+------------------
+
+Promove páginas aprovadas do Notion para issues no GitHub.
+
+Premissas de governança:
+- Notion é captura bruta.
+- GitHub é o ledger canônico.
+- Apenas páginas com Status = APPROVED viram issues.
+- A sincronização cria rastreabilidade, não sobrescreve decisões versionadas.
+
+Variáveis de ambiente:
+- NOTION_API_TOKEN
+- NOTION_DATABASE_ID
+- GITHUB_TOKEN
+- GITHUB_REPO, por exemplo: catcaio/ora-brasiliae-os
+
+Uso:
+    python3 scripts/notion_to_issue.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+NOTION_VERSION = "2022-06-28"
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Environment variable missing: {name}")
+    return value
+
+
+def notion_headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {require_env('NOTION_API_TOKEN')}",
+        "Notion-Version": NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def github_headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {require_env('GITHUB_TOKEN')}",
+        "Accept": "application/vnd.github+json",
+    }
+
+
+def fetch_approved_pages() -> List[Dict[str, Any]]:
+    """Query the Notion database for pages with Status == APPROVED."""
+    database_id = require_env("NOTION_DATABASE_ID")
+    url = f"https://api.notion.com/v1/databases/{database_id}/query"
+    payload = {
+        "filter": {
+            "property": "Status",
+            "select": {"equals": "APPROVED"},
+        }
+    }
+    response = requests.post(url, headers=notion_headers(), json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json().get("results", [])
+
+
+def first_title_property(properties: Dict[str, Any]) -> str:
+    for prop in properties.values():
+        if prop.get("type") == "title":
+            title_items = prop.get("title", [])
+            if title_items:
+                return title_items[0].get("plain_text", "Untitled")
+    return "Untitled"
+
+
+def rich_text_value(prop: Optional[Dict[str, Any]]) -> str:
+    if not prop or prop.get("type") != "rich_text":
+        return ""
+    return "\n".join(item.get("plain_text", "") for item in prop.get("rich_text", []))
+
+
+def select_value(prop: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not prop or prop.get("type") != "select" or not prop.get("select"):
+        return None
+    return prop["select"].get("name")
+
+
+def extract_issue_fields(page: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract title, body and labels from a Notion page payload."""
+    props = page.get("properties", {})
+    title = first_title_property(props)
+    description = rich_text_value(props.get("Description"))
+    issue_type = select_value(props.get("Type"))
+    notion_url = page.get("url", "")
+
+    body_parts = []
+    if description:
+        body_parts.append(description)
+    body_parts.append(f"## Origem\n[Notion Page]({notion_url})")
+    body_parts.append("## Estado inicial\nPromovido automaticamente de Notion APPROVED para GitHub Issue.")
+
+    labels = [issue_type] if issue_type else ["from-notion"]
+    return {"title": title, "body": "\n\n".join(body_parts), "labels": labels}
+
+
+def create_github_issue(issue: Dict[str, Any]) -> Dict[str, Any]:
+    repo = require_env("GITHUB_REPO")
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload: Dict[str, Any] = {
+        "title": issue["title"],
+        "body": issue["body"],
+        "labels": issue.get("labels", []),
+    }
+    response = requests.post(url, headers=github_headers(), json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    pages = fetch_approved_pages()
+    if not pages:
+        print("No APPROVED Notion pages found.")
+        return
+
+    for page in pages:
+        issue_fields = extract_issue_fields(page)
+        created = create_github_issue(issue_fields)
+        print(f"Created issue #{created.get('number')}: {created.get('html_url')}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Origem
Closes #11

## Status
REVIEW

## Objetivo
Implementar os executores mínimos do Ora Brasiliae OS para reduzir o transporte manual de contexto entre IAs e ferramentas.

## Escopo
- [x] Alteração de código
- [x] Documentação
- [x] Infraestrutura/Governança

Arquivos principais:
- `scripts/notion_to_issue.py`
- `scripts/generate_context_package.py`
- `docs/governance/branch-naming.md`
- `docs/governance/integration-routing.md`
- `.github/workflows/validate-pr.yml`
- `.github/workflows/report-to-notion.yml`
- `reports/executions/2026-04-25-workflow-executors.md`

## Validação
Validação por inspeção estrutural dos artefatos versionados e aderência às regras centrais já existentes: GitHub como ledger canônico, Notion como captura bruta e alterações relevantes via PR.

## Evidências
- Issue de origem: #11
- Branch: `feat/11-workflow-executors`
- Relatório: `reports/executions/2026-04-25-workflow-executors.md`

## Riscos
- `notion_to_issue.py` depende de propriedades específicas no Notion: `Status`, opcionalmente `Description` e `Type`.
- `report-to-notion.yml` depende dos secrets `NOTION_API_TOKEN` e `NOTION_PARENT_PAGE_ID`.
- Sem campo de deduplicação no Notion, páginas aprovadas podem gerar issues duplicadas.
- Linear, ClickUp e Slack foram documentados como nós auxiliares, mas automações específicas ainda precisam de rotas por caso de uso.

## Checklist
- [x] Autoria do commit validada
- [x] Relatório de execução gerado
- [x] Sem segredos ou credenciais expostas
- [x] Commits com mensagens claras

## Relatório Final
`reports/executions/2026-04-25-workflow-executors.md`