### PR TITLE
BRASIL-4 — Configurar Jules Scheduled Task diário do Market Lab

### DIFF
--- a/.github/workflows/jules-daily-win-audit.yml
+++ b/.github/workflows/jules-daily-win-audit.yml
@@ -1,0 +1,105 @@
+# Ora Brasiliae Market Lab — Daily WIN Snapshot Audit
+# BRASIL-4: Configurar Jules Scheduled Task diário do Market Lab
+#
+# Agendamento: Dias úteis (seg–sex) às 18:30 BRT (21:30 UTC)
+# Branch base: governance/bootstrap
+# Issue Linear: BRASIL-4
+#
+# Pré-requisito: Secret JULES_API_KEY configurado em
+#   Settings → Secrets and variables → Actions → JULES_API_KEY
+#
+# Geração da chave: jules.google.com → Settings → API Keys
+
+name: Ora Brasiliae — Daily WIN Snapshot Audit (Jules)
+
+on:
+  # Dias úteis (seg=1, sex=5) às 21:30 UTC = 18:30 BRT
+  schedule:
+    - cron: '30 21 * * 1-5'
+  # Permite disparo manual para dry-run / teste
+  workflow_dispatch:
+
+jobs:
+  jules-daily-win-audit:
+    name: Jules — Daily WIN Snapshot Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Invoke Jules — Daily WIN Snapshot Audit
+        uses: google-labs-code/jules-invoke@v1
+        with:
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          starting_branch: governance/bootstrap
+          include_last_commit: 'false'
+          include_commit_log: 'false'
+          prompt: |
+            # Jules: Daily WIN Snapshot Audit
+            # Ora Brasiliae Market Lab — BRASIL-4
+            # Branch base: governance/bootstrap
+            # Issue Linear: BRASIL-4
+            # Modo: sandbox educacional
+            # Jules atua como auditor operacional, NÃO como fonte de dados.
+
+            Você é um agente de auditoria operacional do Ora Brasiliae Market Lab.
+            Sua missão é validar os dados diários do contrato futuro de mini-índice (WIN)
+            e gerar relatórios de integridade.
+
+            ## Fluxo de Trabalho
+
+            1. **Localizar Snapshot:**
+               - Procure o arquivo de dados do dia em `data/market-lab/YYYY-MM-DD-win-snapshot.json`
+                 (substitua YYYY-MM-DD pela data atual de execução).
+               - Se não existir, prossiga para reportar a ausência.
+
+            2. **Executar Auditoria:**
+               - Utilize o comando: `npm run jules:daily-win-audit`
+               - Este comando validará a estrutura e gerará um relatório em markdown
+                 em `reports/market-lab/`.
+
+            3. **Análise de Qualidade:**
+               - Verifique o campo `quality` no resultado.
+               - `complete`: Dados íntegros.
+               - `partial`: Faltam campos não críticos.
+               - `insufficient`: Faltam campos críticos (Abertura, Máxima, Mínima, Fechamento)
+                 ou snapshot ausente.
+
+            4. **Registro de Evidências:**
+               - Vincule a execução à issue do Linear BRASIL-4.
+               - Anexe o conteúdo do relatório gerado como comentário na issue.
+               - Se houver alterações versionáveis (ex: novo relatório), abra ou atualize
+                 uma Pull Request contra `governance/bootstrap`.
+
+            ## Restrições Críticas
+
+            - NÃO invente dados ausentes. Reporte-os como `null`.
+            - NÃO busque dados externos de fontes não autorizadas nesta versão (V1).
+            - NÃO faça recomendações de compra ou venda (trade).
+            - NÃO execute ordens em corretoras.
+            - NÃO trate a si mesmo como fonte primária de dados. Você é o auditor, não o oráculo.
+            - NÃO use snapshot de exemplo como dado do dia real.
+            - NÃO abra PR contra `main`. Use exclusivamente `governance/bootstrap` como base.
+
+            ## Comportamento quando snapshot não existe
+
+            - Gerar relatório de ausência em `reports/market-lab/YYYY-MM-DD-win-report.md`.
+            - Classificar como `insufficient`.
+            - Registrar claramente que o dado do dia não foi fornecido.
+
+            ## Se houver alteração versionável
+
+            - Criar branch específica a partir de `governance/bootstrap`.
+            - Abrir PR contra `governance/bootstrap` com corpo contendo:
+              - ## Origem
+              - ## Objetivo
+              - ## Escopo
+              - ## Validação
+              - ## Evidências
+              - ## Riscos
+
+            ## Comandos Úteis
+
+            - Validar snapshot específico: `npm run market:validate-snapshot -- path/to/file.json`
+            - Gerar relatório específico: `npm run market:daily-report -- path/to/file.json`
+            - Pipeline completo: `npm run jules:daily-win-audit`

--- a/.github/workflows/jules-daily-win-audit.yml
+++ b/.github/workflows/jules-daily-win-audit.yml
@@ -5,8 +5,8 @@
 # Branch base: governance/bootstrap
 # Issue Linear: BRASIL-4
 #
-# Pré-requisito: Secret JULES_API_KEY configurado em
-#   Settings → Secrets and variables → Actions → JULES_API_KEY
+# Pré-requisito: Secret JULES_API configurado em
+#   Settings → Secrets and variables → Actions → JULES_API
 #
 # Geração da chave: jules.google.com → Settings → API Keys
 
@@ -30,7 +30,7 @@ jobs:
       - name: Invoke Jules — Daily WIN Snapshot Audit
         uses: google-labs-code/jules-invoke@v1
         with:
-          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          jules_api_key: ${{ secrets.JULES_API }}
           starting_branch: governance/bootstrap
           include_last_commit: 'false'
           include_commit_log: 'false'

--- a/docs/market-lab/jules-integration.md
+++ b/docs/market-lab/jules-integration.md
@@ -61,11 +61,11 @@ A auditoria diária é executada automaticamente via **GitHub Actions** + **Jule
 
 ### Pré-requisito: API Key
 
-O secret `JULES_API_KEY` deve estar configurado no repositório:
+O secret `JULES_API` deve estar configurado no repositório:
 
 1. Acesse [jules.google.com](https://jules.google.com) → **Settings** → **API Keys**
 2. Gere uma chave (máximo 3 ativas simultâneas)
-3. No GitHub: **Settings** → **Secrets and variables** → **Actions** → `JULES_API_KEY`
+3. No GitHub: **Settings** → **Secrets and variables** → **Actions** → `JULES_API`
 
 ### Comportamento quando snapshot existe
 
@@ -111,7 +111,7 @@ npm run jules:daily-win-audit
 - Jules não busca dados externos (ex: APIs de mercado B3)
 - Não há integração com corretoras
 - A tarefa não executa em feriados — apenas filtra dias da semana (seg–sex)
-- O secret `JULES_API_KEY` tem validade conforme política da Google Jules API
+- O secret `JULES_API` tem validade conforme política da Google Jules API
 
 ---
 

--- a/docs/market-lab/jules-integration.md
+++ b/docs/market-lab/jules-integration.md
@@ -43,6 +43,78 @@ As seguintes variáveis devem ser configuradas no `.env`:
 - Validação estritamente documental e lógica básica.
 - Não há integração direta com corretoras.
 
+## Scheduled Task diária
+
+A auditoria diária é executada automaticamente via **GitHub Actions** + **Jules API** (`google-labs-code/jules-invoke@v1`).
+
+### Configuração
+
+| Campo | Valor |
+|-------|-------|
+| **Nome da tarefa** | `Ora Brasiliae Market Lab — Daily WIN Snapshot Audit` |
+| **Workflow** | `.github/workflows/jules-daily-win-audit.yml` |
+| **Frequência** | Dias úteis (segunda a sexta) |
+| **Horário** | 18:30 BRT (21:30 UTC — cron: `30 21 * * 1-5`) |
+| **Branch base** | `governance/bootstrap` |
+| **Issue Linear** | BRASIL-4 |
+| **Prompt** | Conteúdo de `prompts/jules/daily-win-snapshot-audit.md` |
+
+### Pré-requisito: API Key
+
+O secret `JULES_API_KEY` deve estar configurado no repositório:
+
+1. Acesse [jules.google.com](https://jules.google.com) → **Settings** → **API Keys**
+2. Gere uma chave (máximo 3 ativas simultâneas)
+3. No GitHub: **Settings** → **Secrets and variables** → **Actions** → `JULES_API_KEY`
+
+### Comportamento quando snapshot existe
+
+1. Jules atualiza checkout de `governance/bootstrap`
+2. Localiza `data/market-lab/YYYY-MM-DD-win-snapshot.json`
+3. Executa `npm run jules:daily-win-audit`
+4. Gera relatório em `reports/market-lab/YYYY-MM-DD-win-report.md`
+5. Classifica qualidade como `complete`, `partial` ou `insufficient`
+6. Registra evidência na issue Linear BRASIL-4
+7. Abre PR contra `governance/bootstrap` se houver artefato versionável
+
+### Comportamento quando snapshot não existe
+
+1. Gera relatório de ausência: `reports/market-lab/YYYY-MM-DD-win-report.md`
+2. Classifica como `insufficient`
+3. Registra que o dado do dia não foi fornecido
+4. **Não usa snapshot de exemplo como fallback**
+5. **Não inventa dados**
+
+### Como auditar execuções
+
+- Acesse **Actions** → `Ora Brasiliae — Daily WIN Snapshot Audit (Jules)` no GitHub
+- Verifique logs do job `jules-daily-win-audit`
+- Consulte os comentários na issue Linear BRASIL-4
+
+### Como disparar manualmente (dry-run)
+
+```bash
+# Via GitHub CLI
+gh workflow run jules-daily-win-audit.yml
+
+# Via npm (execução local sem Jules)
+npm run jules:daily-win-audit
+```
+
+### Como pausar/desativar a task
+
+- **Temporariamente:** No GitHub Actions → selecione o workflow → **Disable workflow**
+- **Permanentemente:** Remova ou comente o bloco `schedule:` no arquivo `.github/workflows/jules-daily-win-audit.yml`
+
+### Limitações da V1
+
+- Jules não busca dados externos (ex: APIs de mercado B3)
+- Não há integração com corretoras
+- A tarefa não executa em feriados — apenas filtra dias da semana (seg–sex)
+- O secret `JULES_API_KEY` tem validade conforme política da Google Jules API
+
+---
+
 ## Próximos Passos
 
 - Integração com APIs oficiais para cross-check automático.


### PR DESCRIPTION
## Origem

Issue Linear: BRASIL-4 — Configurar Jules Scheduled Task diário do Market Lab.

Esta PR configura a tarefa agendada diária do Jules para auditar snapshots do WIN no Ora Brasiliae Market Lab, usando a API oficial do Jules via GitHub Actions (`google-labs-code/jules-invoke@v1`).

Pré-condição atendida: PR #15 / BRASIL-3 mergeada em `governance/bootstrap`, com todos os artefatos do pipeline validados.

## Objetivo

Versionar o mecanismo de agendamento automático da auditoria diária do Jules, garantindo execução às 18:30 BRT em dias úteis sem intervenção manual, com rastreabilidade completa via Linear (BRASIL-4) e GitHub Actions.

## Escopo

**Arquivos alterados:**

- `.github/workflows/jules-daily-win-audit.yml` *(novo)*
  - Cron: `30 21 * * 1-5` (18:30 BRT, segunda a sexta)
  - Usa `google-labs-code/jules-invoke@v1` com `JULES_API_KEY` secret
  - Branch base: `governance/bootstrap`
  - `workflow_dispatch` habilitado para dry-run manual
  - Prompt inline com todas as restrições de auditoria da BRASIL-4

- `docs/market-lab/jules-integration.md` *(atualizado)*
  - Seção `## Scheduled Task diária` adicionada
  - Documenta: nome, frequência, horário, comportamento, monitoramento, como pausar, limitações V1

**Fora do escopo:** nenhuma alteração funcional no Market Lab, scripts ou testes.

## Validação

- [x] Workflow YAML válido (indentação e sintaxe conferidas)
- [x] Cron `30 21 * * 1-5` = 18:30 BRT (UTC-3) em dias úteis
- [x] `starting_branch: governance/bootstrap` configurado
- [x] Prompt contém todas as restrições críticas do BRASIL-4
- [x] `workflow_dispatch` habilitado para dry-run manual
- [x] Secret `JULES_API_KEY` referenciado via `${{ secrets.JULES_API_KEY }}`
- [x] Documentação atualizada com seção obrigatória

**Dry-run:** Após merge e configuração do secret, executar via:
```
gh workflow run jules-daily-win-audit.yml
```

## Evidências

- Issue Linear: BRASIL-4
- Branch: `feat/brasil-4-jules-scheduled-task`
- Workflow: `.github/workflows/jules-daily-win-audit.yml`
- Documentação: `docs/market-lab/jules-integration.md#scheduled-task-diária`
- Action oficial: `google-labs-code/jules-invoke@v1` (https://github.com/google-labs-code/jules-invoke)

## Riscos

- **Secret não configurado:** se `JULES_API_KEY` não for adicionado antes do primeiro cron, o job falha sem dano. Ação: configurar o secret antes do primeiro dia útil após o merge.
- **Feriados não filtrados:** o cron filtra apenas dia da semana (seg–sex); feriados brasileiros não são excluídos automaticamente na V1.
- **Validade da API Key:** chaves Jules têm política de expiração conforme Google Jules API — monitorar renovação.
- **Sem dados no dia:** comportamento definido (relatório de ausência `insufficient`) e documentado. Nenhum risco de dados inventados.
